### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A grid library to present tabular data",
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt dist && git add dist/*",
-    "postinstall": "npm prune && bower install && bower prune"
+    "prepublish": "grunt dist && git add dist/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove postinstall script to prevent it from running every time any project that references it does an npm or yarn install, and the errors that may be caused by the script run.