### PR TITLE
Add a main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fixtable",
   "version": "2.0.8",
   "description": "A grid library to present tabular data",
+  "main": "dist/fixtable.min.js",
   "scripts": {
     "test": "grunt test",
     "prepublish": "grunt dist && git add dist/*"


### PR DESCRIPTION
Adding a main path to package.json makes it much easier to use the library with npm installs - makes `require("fixtable")` work, makes it work with webpack without special config, etc.